### PR TITLE
ecm brieflz changes

### DIFF
--- a/example/blzpack.c
+++ b/example/blzpack.c
@@ -491,7 +491,7 @@ main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-#ifdef __WATCOMC__
+#if defined(__WATCOMC__) || defined(__GNUC__)
 	/* Unlike BC, which unbuffers stdout if it is a device, OpenWatcom 1.2
 	   line buffers stdout; this prevents "rotator" trick based on output
 	   of "\r" and writing new line over previous. To make rotator work

--- a/example/blzpack.c
+++ b/example/blzpack.c
@@ -347,7 +347,9 @@ decompress_file(const char *packedname, const char *newname, int use_checksum)
 		}
 
 		/* Decompress data */
-		depackedsize = blz_depack(packed, data, (unsigned long) hdr_depackedsize);
+		depackedsize = blz_depack_safe(
+				packed, (unsigned long) hdr_packedsize,
+				data, (unsigned long) hdr_depackedsize);
 
 		/* Check for decompression error */
 		if (depackedsize != hdr_depackedsize) {


### PR DESCRIPTION
- Use blz_depack_safe in blzpack
- In blzpack, unbuffer stdout when building with gcc too