### PR TITLE
ecm brieflz changes #2

### DIFF
--- a/depack.c
+++ b/depack.c
@@ -73,19 +73,13 @@ unsigned long
 blz_depack(const void *src, void *dst, unsigned long depacked_size)
 {
 	struct blz_state bs;
-	unsigned long dst_size = 1;
-
-	/* Check for empty input */
-	if (depacked_size == 0) {
-		return 0;
-	}
+	unsigned long dst_size = 0;
 
 	bs.src = (const unsigned char *) src;
 	bs.dst = (unsigned char *) dst;
-	bs.bits_left = 0;
-
-	/* First byte verbatim */
-	*bs.dst++ = *bs.src++;
+	/* Initialise to one bit left in tag; that bit is zero (a literal). */
+	bs.bits_left = 1;
+	bs.tag = 0;
 
 	/* Main decompression loop */
 	while (dst_size < depacked_size) {

--- a/depacks.c
+++ b/depacks.c
@@ -98,25 +98,16 @@ blz_depack_safe(const void *src, unsigned long src_size,
                 void *dst, unsigned long depacked_size)
 {
 	struct blz_state bs;
-	unsigned long dst_size = 1;
+	unsigned long dst_size = 0;
 	unsigned int bit;
-
-	/* Check for empty input */
-	if (depacked_size == 0) {
-		return 0;
-	}
 
 	bs.src = (const unsigned char *) src;
 	bs.src_avail = src_size;
 	bs.dst = (unsigned char *) dst;
 	bs.dst_avail = depacked_size;
-	bs.bits_left = 0;
-
-	/* First byte verbatim */
-	if (!bs.src_avail-- || !bs.dst_avail--) {
-		return BLZ_ERROR;
-	}
-	*bs.dst++ = *bs.src++;
+	/* Initialise to one bit left in tag; that bit is zero (a literal). */
+	bs.bits_left = 1;
+	bs.tag = 0;
 
 	/* Main decompression loop */
 	while (dst_size < depacked_size) {

--- a/example/blzpack.c
+++ b/example/blzpack.c
@@ -489,7 +489,7 @@ main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-#ifdef __WATCOMC__
+#if defined(__WATCOMC__) || defined(__GNUC__)
 	/* Unlike BC, which unbuffers stdout if it is a device, OpenWatcom 1.2
 	   line buffers stdout; this prevents "rotator" trick based on output
 	   of "\r" and writing new line over previous. To make rotator work


### PR DESCRIPTION
I accidentally deleted/closed the other pull request. Here's some new changes that I discovered. The unbuffering change is the same one I made first. Other changes: --blocksize can increase or decrease the block size, giving --safe makes blzpack use blz_depack_safe, --pad uses a trick to align subsequent headers on an 8-byte boundary, and I optimised the depacker a little.